### PR TITLE
WorldEdit restriction

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -43,7 +43,9 @@
     - [ ] PlaceholderAPI
     - [ ] Vault (Maybe? Not sure for what)
     - [ ] WorldGuard (Overlap compatibility checking?)
-    - [ ] WorldEdit (Creating from selection, visuals)
+  - [ ] WorldEdit
+      - [x] Zone-based restrictions
+      - [ ] Selection integration (Visuals, Creation)
 - [ ]  Other:
     - [ ] Better error handling
     - [ ] Storage Methods:

--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,15 @@ repositories {
         name = "sonatype"
         url = "https://oss.sonatype.org/content/groups/public/"
     }
+    maven {
+        name = "EngineHub"
+        url = "https://maven.enginehub.org/repo/"
+    }
 }
 
 dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT'
+    compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.3.0'
     //paperweight.paperDevBundle("1.21.1-R0.1-SNAPSHOT")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT'
     compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.3.0'
     //paperweight.paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+    implementation(platform("com.intellectualsites.bom:bom-newest:1.52"))
+    compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Core")
+    compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Bukkit")
 }
 
 def targetJavaVersion = 21

--- a/src/main/java/de/t14d3/zones/Zones.java
+++ b/src/main/java/de/t14d3/zones/Zones.java
@@ -1,6 +1,8 @@
 package de.t14d3.zones;
 
+import com.fastasyncworldedit.core.util.WEManager;
 import com.sk89q.worldedit.WorldEdit;
+import de.t14d3.zones.integrations.FAWEIntegration;
 import de.t14d3.zones.integrations.WorldEditSession;
 import de.t14d3.zones.listeners.CommandListener;
 import de.t14d3.zones.listeners.PlayerInteractListener;
@@ -98,6 +100,10 @@ public final class Zones extends JavaPlugin {
         if (getServer().getPluginManager().getPlugin("WorldEdit") != null) {
             WorldEdit.getInstance().getEventBus().register(new WorldEditSession(this));
             getLogger().info("WorldEdit Integration enabled.");
+        }
+        if (getServer().getPluginManager().getPlugin("FastAsyncWorldEdit") != null) {
+            WEManager.weManager().addManager(new FAWEIntegration(this));
+            getLogger().info("FAWE Integration enabled.");
         }
 
         getLogger().info("Zones plugin has been enabled! Loaded " + regionManager.loadedRegions.size() + " regions.");

--- a/src/main/java/de/t14d3/zones/Zones.java
+++ b/src/main/java/de/t14d3/zones/Zones.java
@@ -1,5 +1,7 @@
 package de.t14d3.zones;
 
+import com.sk89q.worldedit.WorldEdit;
+import de.t14d3.zones.integrations.WorldEditSession;
 import de.t14d3.zones.listeners.CommandListener;
 import de.t14d3.zones.listeners.PlayerInteractListener;
 import de.t14d3.zones.listeners.PlayerQuitListener;
@@ -92,6 +94,10 @@ public final class Zones extends JavaPlugin {
                 regionManager.saveRegions();
                 getLogger().info("Zones have been saved.");
             }, 20L, getConfig().getInt("zone-saving.period", 60) * 20L);
+        }
+        if (getServer().getPluginManager().getPlugin("WorldEdit") != null) {
+            WorldEdit.getInstance().getEventBus().register(new WorldEditSession(this));
+            getLogger().info("WorldEdit Integration enabled.");
         }
 
         getLogger().info("Zones plugin has been enabled! Loaded " + regionManager.loadedRegions.size() + " regions.");

--- a/src/main/java/de/t14d3/zones/integrations/FAWEIntegration.java
+++ b/src/main/java/de/t14d3/zones/integrations/FAWEIntegration.java
@@ -1,0 +1,61 @@
+package de.t14d3.zones.integrations;
+
+import com.fastasyncworldedit.bukkit.regions.BukkitMaskManager;
+import com.fastasyncworldedit.core.regions.FaweMask;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import de.t14d3.zones.Region;
+import de.t14d3.zones.Zones;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+public class FAWEIntegration extends BukkitMaskManager {
+
+    private final Zones plugin;
+
+    public FAWEIntegration(final Zones plugin) {
+        super(plugin.getName());
+        this.plugin = plugin;
+    }
+
+    public boolean isAllowed(Player player, Region region, MaskType type) {
+        return region != null &&
+                (region.isAdmin(player.getUniqueId()) ||
+                        type == MaskType.MEMBER && (
+                                plugin.getPermissionManager().hasPermission(player.getUniqueId(), "PLACE", "true", region)
+                                        || plugin.getPermissionManager().hasPermission(player.getUniqueId(), "BREAK", "true", region)));
+    }
+
+    @Override
+    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, final MaskType type, boolean isWhitelist) {
+        final Player player = BukkitAdapter.adapt(wePlayer);
+        final Location location = player.getLocation();
+        List<Region> regions = plugin.getRegionManager().getRegionsAt(location);
+        if (!regions.isEmpty()) {
+            boolean isAllowed = true;
+            for (Region region : regions) {
+                if (!isAllowed(player, region, type)) {
+                    isAllowed = false;
+                    break;
+                }
+            }
+            if (isAllowed) {
+                final Location pos1 = regions.get(0).getMin();
+                final Location pos2 = regions.get(0).getMax();
+                final Region region = regions.get(0);
+                return new FaweMask(new CuboidRegion(BukkitAdapter.asBlockVector(pos1), BukkitAdapter.asBlockVector(pos2))) {
+                    @Override
+                    public boolean isValid(com.sk89q.worldedit.entity.Player player, MaskType type) {
+                        return isAllowed(BukkitAdapter.adapt(player), region, type);
+                    }
+                };
+            }
+        }
+
+
+        return null;
+    }
+
+}

--- a/src/main/java/de/t14d3/zones/integrations/WorldEditExtent.java
+++ b/src/main/java/de/t14d3/zones/integrations/WorldEditExtent.java
@@ -1,0 +1,28 @@
+package de.t14d3.zones.integrations;
+
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.extent.AbstractDelegateExtent;
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+
+import java.util.Set;
+
+public class WorldEditExtent extends AbstractDelegateExtent {
+    private final Set<CuboidRegion> mask;
+
+    public WorldEditExtent(Set<CuboidRegion> mask, Extent extent) {
+        super(extent);
+        this.mask = mask;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+        if (!WorldEditSession.WorldEditUtils.maskContains(this.mask, location.x(), location.y(), location.z())) {
+            return false;
+        }
+        return super.setBlock(location, block);
+    }
+}

--- a/src/main/java/de/t14d3/zones/integrations/WorldEditSession.java
+++ b/src/main/java/de/t14d3/zones/integrations/WorldEditSession.java
@@ -1,0 +1,70 @@
+package de.t14d3.zones.integrations;
+
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.event.extent.EditSessionEvent;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.util.eventbus.Subscribe;
+import de.t14d3.zones.Region;
+import de.t14d3.zones.Zones;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class WorldEditSession {
+    private final Zones plugin;
+    private final WorldEditUtils utils;
+
+
+    public WorldEditSession(Zones plugin) {
+        this.plugin = plugin;
+        this.utils = new WorldEditUtils();
+    }
+
+    @Subscribe
+    public void onEditSessionEvent(EditSessionEvent event) {
+        if (event.getStage() == EditSession.Stage.BEFORE_REORDER) {
+            Player player = null;
+            if (event.getActor().isPlayer()) {
+                player = Bukkit.getPlayer(event.getActor().getName());
+            }
+            Set<CuboidRegion> mask = utils.getMask(player);
+            event.setExtent(new WorldEditExtent(mask, event.getExtent()));
+        }
+    }
+
+    public class WorldEditUtils {
+        public HashSet<CuboidRegion> getMask(Player player) {
+            HashSet<CuboidRegion> mask = new HashSet<>();
+            for (Region region : plugin.getRegionManager().regions().values()) {
+                if ((plugin.getPermissionManager().hasPermission(player.getUniqueId(), "PLACE", "true", region)
+                        && plugin.getPermissionManager().hasPermission(player.getUniqueId(), "BREAK", "true", region))
+                        || region.isAdmin(player.getUniqueId())) {
+                    mask.add(new CuboidRegion(
+                            BukkitAdapter.asBlockVector(region.getMin()),
+                            BukkitAdapter.asBlockVector(region.getMax().clone().subtract(1, 1, 1)) // Don't ask me why, but it works
+                    ));
+                }
+            }
+            return mask;
+        }
+
+        public static boolean cuboidRegionContains(CuboidRegion region, int x, int y, int z) {
+            return region.getMinimumPoint().x() <= x && region.getMaximumPoint().x() >= x &&
+                    region.getMinimumPoint().y() <= y && region.getMaximumPoint().y() >= y &&
+                    region.getMinimumPoint().z() <= z && region.getMaximumPoint().z() >= z;
+        }
+
+        public static boolean maskContains(Set<CuboidRegion> mask, int x, int y, int z) {
+            for (CuboidRegion region : mask) {
+                if (cuboidRegionContains(region, x, y, z)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: Zones
 version: '${version}'
 main: de.t14d3.zones.Zones
 api-version: '1.21'
+softdepend: [ WorldEdit, FastAsyncWorldEdit ]
 commands:
   zone:
     description: Main Command


### PR DESCRIPTION
Adds support for restricting WorldEdit operations based on zone permissions.

Replaces https://github.com/IntellectualSites/FastAsyncWorldEdit/pull/3067