### PR TITLE
Region priority

### DIFF
--- a/src/main/java/de/t14d3/zones/PermissionManager.java
+++ b/src/main/java/de/t14d3/zones/PermissionManager.java
@@ -4,7 +4,6 @@ import de.t14d3.zones.utils.Actions;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.util.BoundingBox;
 
 import java.util.Map;
 import java.util.UUID;
@@ -34,6 +33,12 @@ public class PermissionManager {
      * @return True if the player can interact with the region, false otherwise.
      */
     public boolean canInteract(Location location, UUID playerUUID, Actions action, String type) {
+
+        // Skip checking if player has global bypass permission
+        Player player = Bukkit.getPlayer(playerUUID);
+        if (player != null && player.hasPermission("zones.bypass.claimed")) {
+            return true;
+        }
         if (interactionCache.containsKey(playerUUID)) {
             ConcurrentLinkedQueue<CacheEntry> entries = interactionCache.get(playerUUID);
             for (CacheEntry entry : entries) {
@@ -42,19 +47,35 @@ public class PermissionManager {
                 }
             }
         }
-        for (Map.Entry<String, Region> entry : regionManager.regions().entrySet()) {
-            Region region = entry.getValue();
-            BoundingBox box = BoundingBox.of(region.getMin(), region.getMax());
+        if (!regionManager.getRegionsAt(location).isEmpty()) {
+            Result result = Result.UNDEFINED;
+            int priority = Integer.MIN_VALUE;
 
-            if (box.contains(location.toVector())) {
-                Result hasPermission = hasPermission(playerUUID.toString(), action.name(), type, region);
-                interactionCache.computeIfAbsent(playerUUID, k -> new ConcurrentLinkedQueue<>()).add(new CacheEntry(location, action.name(), type, hasPermission));
+            for (Region region : regionManager.getRegionsAt(location)) {
 
-                return hasPermission.equals(Result.TRUE);
+                // Only check regions with a higher priority than the current value
+                if (region.getPriority() > priority) {
+                    Result hasPermission = hasPermission(playerUUID.toString(), action.name(), type, region);
+                    if (!hasPermission.equals(Result.UNDEFINED)) {
+                        result = hasPermission;
+                        priority = region.getPriority();
+                        continue;
+                    }
+                }
+                // If same priority, both have to be true, otherwise will assume false
+                else if (region.getPriority() == priority) {
+                    Result hasPermission = hasPermission(playerUUID.toString(), action.name(), type, region);
+                    if (hasPermission.equals(Result.FALSE) || result.equals(Result.FALSE)) {
+                        result = hasPermission;
+                        priority = region.getPriority();
+                        continue;
+                    }
+                }
             }
-        }
 
-        Player player = Bukkit.getPlayer(playerUUID);
+            return result.equals(Result.TRUE);
+        }
+        // If no region found, check for unclaimed bypass perm and return false if not found
         return player != null && player.hasPermission("zones.bypass.unclaimed");
     }
 

--- a/src/main/java/de/t14d3/zones/PermissionManager.java
+++ b/src/main/java/de/t14d3/zones/PermissionManager.java
@@ -185,11 +185,6 @@ public class PermissionManager {
         } catch (IllegalArgumentException ignored) {
         }
 
-        // Check if player has a global bypass permission
-        if (player != null && player.hasPermission("zones.bypass.claimed")) {
-            return Result.TRUE;
-        }
-
         Result result = Result.UNDEFINED; // Initialize result as null
 
         // Check if player is an admin, but only if not checking

--- a/src/main/java/de/t14d3/zones/Region.java
+++ b/src/main/java/de/t14d3/zones/Region.java
@@ -22,41 +22,46 @@ public class Region {
     private Map<String, Map<String, String>> members;
     private String key;
     private String parent;
+    private int priority;
 
     // Constructor
     /**
      * Constructs a new region with the given name, minimum and maximum locations, members and parent.
-     * @param name The name of the region (not unique).
-     * @param min The minimum location of the region.
-     * @param max The maximum location of the region.
-     * @param members The members of the region.
-     * @param key The key of the region.
-     * @param parent The parent (if any) of the region.
      *
-     * @see #Region(String, Location, Location, Map, String)
+     * @param name     The name of the region (not unique).
+     * @param min      The minimum location of the region.
+     * @param max      The maximum location of the region.
+     * @param members  The members of the region.
+     * @param key      The key of the region.
+     * @param parent   The parent (if any) of the region.
+     * @param priority The priority of the region.
+     * @see #Region(String, Location, Location, Map, String, int)
      */
-    Region(@NotNull String name, @NotNull Location min, @NotNull Location max, Map<String, Map<String, String>> members, @NotNull String key, @Nullable String parent) {
+    Region(@NotNull String name, @NotNull Location min, @NotNull Location max, Map<String, Map<String, String>> members, @NotNull String key, @Nullable String parent, int priority) {
         this.name = name;
         this.min = min;
         this.max = max;
         this.members = (members != null) ? members : new HashMap<>();
         this.key = key;
         this.parent = parent;
+        this.priority = priority;
     }
 
     // Constructor overload for regions without parent
     /**
      * Constructs a new region with the given name, minimum and maximum locations, and members.
-     * @param name The name of the region (not unique).
-     * @param min The minimum location of the region.
-     * @param max The maximum location of the region.
-     * @param members The members of the region.
-     * @param key The key of the region.
      *
-     * @see #Region(String, Location, Location, Map, String)
+     * @param name     The name of the region (not unique).
+     * @param min      The minimum location of the region.
+     * @param max      The maximum location of the region.
+     * @param members  The members of the region.
+     * @param key      The key of the region.
+     * @param priority The priority of the region.
+     *
+     * @see #Region(String, Location, Location, Map, String, int)
      */
-    Region(String name, Location min, Location max, Map<String, Map<String, String>> members, String key) {
-        this(name, min, max, members, key, null);
+    Region(String name, Location min, Location max, Map<String, Map<String, String>> members, String key, int priority) {
+        this(name, min, max, members, key, null, priority);
     }
 
     // Getters and Setters
@@ -238,6 +243,14 @@ public class Region {
             }
         }
         return null;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
     }
 
 

--- a/src/main/java/de/t14d3/zones/RegionManager.java
+++ b/src/main/java/de/t14d3/zones/RegionManager.java
@@ -388,14 +388,33 @@ public class RegionManager {
             return foundRegions;
         }
         for (Region region : regions().values()) {
-            BoundingBox regionBox = BoundingBox.of(region.getMin(), region.getMax());
-            // Check if the location's bounding box overlaps with the region's bounding box
-            if (regionBox.contains(location.toVector())) {
+            if (region.contains(location)) {
                 foundRegions.add(region);
+                regionCache.computeIfAbsent(location, k -> new ArrayList<>()).add(region.getKey());
             }
         }
 
+
         return foundRegions;
+    }
+
+    /**
+     * Gets the region with the highest priority at the given location
+     *
+     * @param location Location to check
+     * @return Region at location
+     */
+    public Region getEffectiveRegionAt(Location location) {
+        List<Region> regions = getRegionsAt(location);
+        int priority = Integer.MIN_VALUE;
+        Region effectiveRegion = null;
+        for (Region region : regions) {
+            if (region.getPriority() > priority) {
+                effectiveRegion = region;
+                priority = region.getPriority();
+            }
+        }
+        return effectiveRegion;
     }
 
     /**

--- a/src/main/java/de/t14d3/zones/RegionManager.java
+++ b/src/main/java/de/t14d3/zones/RegionManager.java
@@ -80,6 +80,7 @@ public class RegionManager {
             loadedRegions.clear();
             for (String key : Objects.requireNonNull(regionsConfig.getConfigurationSection("regions")).getKeys(false)) {
                 String name = regionsConfig.getString("regions." + key + ".name");
+                int priority = regionsConfig.getInt("regions." + key + ".priority");
                 Location min = loadLocation("regions." + key + ".min");
                 Location max = loadLocation("regions." + key + ".max");
                 String parent = regionsConfig.getString("regions." + key + ".parent");
@@ -120,6 +121,7 @@ public class RegionManager {
     // Save a region to the YAML file
     public void saveRegion(String key, Region region) {
         regionsConfig.set("regions." + key + ".name", region.getName());
+        regionsConfig.set("regions." + key + ".priority", region.getPriority());
         saveLocation("regions." + key + ".min", region.getMin());
         saveLocation("regions." + key + ".max", region.getMax());
         if (region.getParent() != null) {

--- a/src/main/java/de/t14d3/zones/RegionManager.java
+++ b/src/main/java/de/t14d3/zones/RegionManager.java
@@ -85,7 +85,7 @@ public class RegionManager {
                 String parent = regionsConfig.getString("regions." + key + ".parent");
 
                 Map<String, Map<String, String>> members = loadMembers(key);
-                Region region = new Region(name != null ? name : "Invalid Name", min, max, members, key, parent);
+                Region region = new Region(name != null ? name : "Invalid Name", min, max, members, key, parent, 0);
                 loadedRegions.put(key, region);
             }
             regionCache.clear();
@@ -186,7 +186,7 @@ public class RegionManager {
         } while (regions().containsKey(regionKey));
 
         Map<String, Map<String, String>> members = new HashMap<>();
-        Region newRegion = new Region(name, min, max, members, regionKey);
+        Region newRegion = new Region(name, min, max, members, regionKey, 0);
 
         ownerPermissions.forEach((permission, value) -> {
             newRegion.addMemberPermission(playerUUID, permission, value, this);
@@ -224,7 +224,7 @@ public class RegionManager {
      * @return The newly created region.
      */
     public Region createNewRegion(String key, String name, Location min, Location max, Map<String, Map<String, String>> members) {
-        Region region = new Region(name, min, max, members, key);
+        Region region = new Region(name, min, max, members, key, 0);
         saveRegion(key, region);
         return region;
     }
@@ -261,7 +261,7 @@ public class RegionManager {
         } while (regions().containsKey(regionKey));
 
         Map<String, Map<String, String>> members = new HashMap<>();
-        Region newRegion = new Region(name, min, max, members, regionKey, parentRegion.getKey());
+        Region newRegion = new Region(name, min, max, members, regionKey, parentRegion.getKey(), 0);
 
         ownerPermissions.forEach((permission, value) -> {
             newRegion.addMemberPermission(playerUUID, permission, value, this);

--- a/src/main/java/de/t14d3/zones/RegionManager.java
+++ b/src/main/java/de/t14d3/zones/RegionManager.java
@@ -8,6 +8,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.util.BoundingBox;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -402,9 +403,9 @@ public class RegionManager {
      * Gets the region with the highest priority at the given location
      *
      * @param location Location to check
-     * @return Region at location
+     * @return Region at location, or null if no region found
      */
-    public Region getEffectiveRegionAt(Location location) {
+    public @Nullable Region getEffectiveRegionAt(Location location) {
         List<Region> regions = getRegionsAt(location);
         int priority = Integer.MIN_VALUE;
         Region effectiveRegion = null;

--- a/src/main/java/de/t14d3/zones/RegionManager.java
+++ b/src/main/java/de/t14d3/zones/RegionManager.java
@@ -225,8 +225,8 @@ public class RegionManager {
      * @param members The members of the new region.
      * @return The newly created region.
      */
-    public Region createNewRegion(String key, String name, Location min, Location max, Map<String, Map<String, String>> members) {
-        Region region = new Region(name, min, max, members, key, 0);
+    public Region createNewRegion(String key, String name, Location min, Location max, Map<String, Map<String, String>> members, int priority) {
+        Region region = new Region(name, min, max, members, key, priority);
         saveRegion(key, region);
         return region;
     }
@@ -494,7 +494,7 @@ public class RegionManager {
 
     /**
      * Adds a region to the loaded regions map.
-     * Requires an existing region object, to create a new region use {@link #createNewRegion(String, String, Location, Location, Map)}.
+     * Requires an existing region object, to create a new region use {@link #createNewRegion(String, String, Location, Location, Map, int)}.
      *
      * @param region The region to add.
      *

--- a/src/main/java/de/t14d3/zones/Zones.java
+++ b/src/main/java/de/t14d3/zones/Zones.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class Zones extends JavaPlugin {
 
@@ -31,7 +32,7 @@ public final class Zones extends JavaPlugin {
     private BeaconUtils beaconUtils;
     private ParticleHandler particleHandler;
     public Map<UUID, Pair<Location, Location>> selection = new HashMap<>();
-    public Map<UUID, BoundingBox> particles = new HashMap<>();
+    public ConcurrentHashMap<UUID, BoundingBox> particles = new ConcurrentHashMap<>();
     private Types types;
     private Messages messages;
     private static Zones instance;

--- a/src/main/java/de/t14d3/zones/integrations/FAWEIntegration.java
+++ b/src/main/java/de/t14d3/zones/integrations/FAWEIntegration.java
@@ -10,8 +10,6 @@ import de.t14d3.zones.Zones;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
-import java.util.List;
-
 public class FAWEIntegration extends BukkitMaskManager {
 
     private final Zones plugin;
@@ -37,19 +35,10 @@ public class FAWEIntegration extends BukkitMaskManager {
     public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, final MaskType type, boolean isWhitelist) {
         final Player player = BukkitAdapter.adapt(wePlayer);
         final Location location = player.getLocation();
-        List<Region> regions = plugin.getRegionManager().getRegionsAt(location);
-        if (!regions.isEmpty()) {
-            boolean isAllowed = true;
-            for (Region region : regions) {
-                if (!isAllowed(player, region, type)) {
-                    isAllowed = false;
-                    break;
-                }
-            }
-            if (isAllowed) {
-                final Location pos1 = regions.get(0).getMin();
-                final Location pos2 = regions.get(0).getMax();
-                final Region region = regions.get(0);
+        Region region = plugin.getRegionManager().getEffectiveRegionAt(location);
+        if (isAllowed(player, region, type)) {
+            final Location pos1 = region.getMin();
+            final Location pos2 = region.getMax();
                 return new FaweMask(new CuboidRegion(BukkitAdapter.asBlockVector(pos1), BukkitAdapter.asBlockVector(pos2))) {
                     @Override
                     public boolean isValid(com.sk89q.worldedit.entity.Player player, MaskType type) {
@@ -57,10 +46,6 @@ public class FAWEIntegration extends BukkitMaskManager {
                     }
                 };
             }
-        }
-
-
         return null;
     }
-
 }

--- a/src/main/java/de/t14d3/zones/integrations/PlaceholderAPI.java
+++ b/src/main/java/de/t14d3/zones/integrations/PlaceholderAPI.java
@@ -55,6 +55,8 @@ public class PlaceholderAPI extends PlaceholderExpansion {
                 "%zones_get_max_x%",
                 "%zones_get_max_y%",
                 "%zones_get_max_z%",
+                "%zones_get_priority%",
+                "%zones_get_parent%",
                 "%zones_is_member%",
                 "%zones_can_place_hand%",
                 "%zones_can_break_target%",
@@ -188,6 +190,18 @@ public class PlaceholderAPI extends PlaceholderExpansion {
                 return plugin.getPermissionManager().canInteract(player.getLocation(), player.getUniqueId(), Actions.valueOf(action), type) ? "true" : "false";
             }
             return "false";
+        }
+        if (params.equalsIgnoreCase("get_priority")) {
+            if (!regions.isEmpty()) {
+                return String.valueOf(regions.get(0).getPriority());
+            }
+            return "0";
+        }
+        if (params.equalsIgnoreCase("get_parent")) {
+            if (!regions.isEmpty()) {
+                return regions.get(0).getParent();
+            }
+            return "";
         }
         return null;
     }

--- a/src/main/java/de/t14d3/zones/integrations/WorldGuardImporter.java
+++ b/src/main/java/de/t14d3/zones/integrations/WorldGuardImporter.java
@@ -47,7 +47,7 @@ public class WorldGuardImporter {
                     region.getMembers().getUniqueIds().forEach(uuid -> members.put(uuid.toString(), Map.of("group", "member")));
                     region.getOwners().getUniqueIds().forEach(uuid -> members.put(uuid.toString(), Map.of("role", "owner")));
 
-                    Region newRegion = plugin.getRegionManager().createNewRegion(key, name, min, max, members);
+                    Region newRegion = plugin.getRegionManager().createNewRegion(key, name, min, max, members, region.getPriority());
                     plugin.getRegionManager().addRegion(newRegion);
                     count[0]++;
                 }


### PR DESCRIPTION
Allow defining region priorities.
Regions with higher priority have the final say in interactions where a location is contained in multiple regions.
If two regions have the same priority, both must permit the action for it to be allowed.